### PR TITLE
Feat/existing_tiles_dict

### DIFF
--- a/src/collections.py
+++ b/src/collections.py
@@ -236,11 +236,17 @@ class Ingestor:
         for tile_path in self.file_list:
             # Get the sensing time from the tile path
             folder_name = tile_path.split("/")[sensing_time_position["path"]]
-            parts = folder_name.split(sensing_time_position["delimiter"])
+            
+            # Handle empty or None delimiter for datetime extraction
+            if sensing_time_position["delimiter"] in ("", None):
+                # No delimiter, use the whole folder name
+                parts = [folder_name]
+            else:
+                parts = folder_name.split(sensing_time_position["delimiter"])
+            
             if isinstance(sensing_time_position["position"], int):
                 datetime_str = parts[sensing_time_position["position"]]
             else:
-
                 datetime_str = "".join(
                     [parts[i] for i in sensing_time_position["position"]]
                 )
@@ -255,10 +261,15 @@ class Ingestor:
             base_name = name_parts[0]
             extension = f".{name_parts[1]}" if len(name_parts) > 1 else ""
 
-            # Replace band identifier in the base name
-            split_file_name = base_name.split(band_position["delimiter"])
-            split_file_name[band_position["position"]] = "(BAND)"
-            new_base_name = band_position["delimiter"].join(split_file_name)
+            # Handle empty or None delimiter for band extraction
+            if band_position["delimiter"] in ("", None):
+                # No delimiter, cannot extract band - use entire base name as placeholder
+                new_base_name = "(BAND)"
+            else:
+                # Replace band identifier in the base name
+                split_file_name = base_name.split(band_position["delimiter"])
+                split_file_name[band_position["position"]] = "(BAND)"
+                new_base_name = band_position["delimiter"].join(split_file_name)
 
             # Reconstruct filename with extension
             new_file_name = new_base_name + extension

--- a/src/collections.py
+++ b/src/collections.py
@@ -306,7 +306,8 @@ class Ingestor:
         existing_tiles = list(self.byoc_client.iter_tiles(self.byoc_collection))
         for tile in byoc_tiles:
             byoc_tile = ByocTile(path=tile[0], sensing_time=tile[1])
-            if byoc_tile.path not in [x.path for x in existing_tiles]:
+            existing_paths = [x["path"] if isinstance(x, dict) else x.path for x in existing_tiles]
+            if byoc_tile.path not in existing_paths:
                 self.byoc_client.create_tile(self.byoc_collection, byoc_tile)
 
     def collection_tile_report(self) -> Tuple[Dict[str, int], List[str]]:


### PR DESCRIPTION
Existing tiles are returned as dictionaries by the API, not as objects with a .path attribute. The code now correctly accesses the path from the dictionary using x["path"].